### PR TITLE
Linux compatibility changes

### DIFF
--- a/hook-impl.sh
+++ b/hook-impl.sh
@@ -25,7 +25,7 @@ which-silent() {
 PIDFILE=/tmp/eslint-$(pwd | (which-silent md5sum && md5sum || md5) | cut -d' ' -f1) 2>/dev/null
 if [ -e $PIDFILE ]
 then
-  if test $(find $PIDFILE -mtime -30s)
+  if test $(find $PIDFILE -newermt '30 seconds ago')
   then
     pkill -g $(cat $PIDFILE)
   fi

--- a/hook-impl.sh
+++ b/hook-impl.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 notify() {
-  if which -s osascript
+  if which-silent osascript
   then
     osascript -e 'display notification "'"$2"'" with title "'"$1"'"'
-  elif which -s notify-send
+  elif which-silent notify-send
   then
     notify-send "$1" "$2"
   fi
@@ -18,7 +18,11 @@ notify-success() {
   notify "Eslint success: $(basename $(pwd))" "Eslint was completed without issues for $(basename $(pwd))"
 }
 
-PIDFILE=/tmp/eslint-$(pwd | (which -s md5sum && md5sum || md5)) 2>/dev/null
+which-silent() {
+  which $1 1>/dev/null
+}
+
+PIDFILE=/tmp/eslint-$(pwd | (which-silent md5sum && md5sum || md5) | cut -d' ' -f1) 2>/dev/null
 if [ -e $PIDFILE ]
 then
   if test $(find $PIDFILE -mtime -30s)
@@ -27,7 +31,7 @@ then
   fi
 fi
 
-if which -s osascript || which -s notify-send
+if which-silent osascript || which-silent notify-send
 then
   (
     npm run-script eslint --silent &>/dev/null && notify-success || notify-failure


### PR DESCRIPTION
- GNU `which` does not have `-s` argument so I replaced it with home-baked `which-silent` function.
- `md5sum` added extra `-` after hash so I added a `cut` command to cut it out.
- In GNU `find` you can give `-mtime` only a parameter that represents hours, so changed it to `-newermt`

In addition, I recommend parameter `-max-warnings 0` to eslint command.